### PR TITLE
第一次npm start报错：引入lorem的路径有问题，做了微小修改

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,2 +1,1 @@
-API_PATH=https://sua.zhaoji.wang/api/v1
-API_PATH_V2=https://api.scu.plus/sua/v2
+API_PATH=<URL>

--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,2 @@
-API_PATH=<URL>
+API_PATH=https://sua.zhaoji.wang/api/v1
+API_PATH_V2=https://api.scu.plus/sua/v2

--- a/src/plugins/course-info-exchange/EvaluateSelectedCourses.vue
+++ b/src/plugins/course-info-exchange/EvaluateSelectedCourses.vue
@@ -29,7 +29,7 @@ import { getCourseTeacherList } from '@/helper/getter'
 import * as ueip from '@/plugins/user-experience-improvement-program'
 import { SemesterInfoExchange } from './types'
 import { SemesterScoreRecord } from '../score/types'
-import { lorem } from 'faker/locale/zh_CN'
+// import { lorem } from 'faker/locale/zh_CN'
 
 @Component({
   components: { Loading, SemesterCard }
@@ -101,7 +101,8 @@ export default class EvaluateSelectedCourses extends Vue {
                       teacherStudentRelationship:
                         Math.floor(Math.random() * 5) + 1,
                       homeworkDifficulty: Math.floor(Math.random() * 5) + 1,
-                      comment: lorem.text()
+                      // comment: lorem.text()
+                      comment: '暂无',
                     }
                   })
             })


### PR DESCRIPTION
第一次载入，引入lorem的路径有问题，做了微小修改

（若图片加载不出，可以去gitee查看，之前提了个issue）
码云：https://gitee.com/frederick-wang/scu-urp-assistant/issues/I1PYOY

<br>
<br>
<hr>
<br>

# npm run dev报错

第一次从git中导入仓库，执行npm install后，运行npm run dev报错。


![输入图片说明](https://images.gitee.com/uploads/images/2020/0803/113933_40dc405f_2285893.png "屏幕截图.png")



![输入图片说明](https://images.gitee.com/uploads/images/2020/0803/114017_915f76ac_2285893.png "屏幕截图.png")


![输入图片说明](https://images.gitee.com/uploads/images/2020/0803/114055_6a75fd74_2285893.png "屏幕截图.png")



发现是导入模块lorem时的路径问题, 这个lorem应该是生成随机文本的意思吧...“乱数假文”

将lorem相关的两个句子注释掉后， lorem.text()替换为'暂无'，编译成功。

![输入图片说明](https://images.gitee.com/uploads/images/2020/0803/115800_2418b695_2285893.png "屏幕截图.png")


![输入图片说明](https://images.gitee.com/uploads/images/2020/0803/115933_2ed3769f_2285893.png "屏幕截图.png")


![输入图片说明](https://images.gitee.com/uploads/images/2020/0803/115946_aebf7c82_2285893.png "屏幕截图.png")

<br>
<hr>
<br>


